### PR TITLE
Pin tracing-core version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,6 +5902,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
+ "tracing-core",
  "try-runtime-cli",
  "xcm",
 ]
@@ -10847,9 +10848,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.9",
@@ -10870,11 +10871,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
- "once_cell",
+ "lazy_static",
  "valuable",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,8 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.137", features = ["derive"] }
 hex-literal = "0.3.4"
 jsonrpsee = { version = "0.14.0", features = ["server"] }
+# Remove in future Polkadot release (9.28?)
+tracing-core = "=0.1.26"
 
 # Local
 parachain-template-runtime = { path = "../runtime" }


### PR DESCRIPTION
A bug was introduced in a tracing dependency that causes RPC log messages not to appear: https://github.com/paritytech/substrate/issues/11691

This impacts external tooling used for launch local testnets (polkadot-launch, zombienet).  Pinning the dependency will allow RPC messages to appear and fix these tools.